### PR TITLE
Rename repo name (#118)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AtCoderHub
+# AtCoderClans
 
 ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/KATO-Hiro/AtCoderHub/TOC%20Generator)
 [![Issues](https://img.shields.io/github/issues/KATO-Hiro/AtCoderHub)](https://github.com/KATO-Hiro/AtCoderHub/issues)


### PR DESCRIPTION
Reason:
AtCoderHub has already existed