### PR TITLE
kyoprustecean の招待リンクを無期限にする

### DIFF
--- a/docs/sns/index.md
+++ b/docs/sns/index.md
@@ -12,7 +12,7 @@ title: SNS
 
 - [競プロer集会所](http://discord.gg/2xCjYvK) - [mencotton](https://atcoder.jp/users/mencotton)さんによって管理・運営されている、競技プログラミングの話題に特化した会話ができるグループ。2020年10月時点で500人以上が参加している。有志による「質問への回答」や「記事の紹介」など多数のチャンネルが用意されている。
 
-- [𝙠𝙮𝙤𝙥𝙧𝙪𝙨𝙩𝙚𝙘𝙚𝙖𝙣𝙨](https://discord.com/invite/MbuqR59t) - [ngtkana](https://atcoder.jp/users/ngtkana)さんによって運営されている、Rustで競技プログラミングに参加している人・参加したい人向けのサーバ。
+- [𝙠𝙮𝙤𝙥𝙧𝙪𝙨𝙩𝙚𝙘𝙚𝙖𝙣𝙨](https://discord.gg/RmRCzPnFPc) - [ngtkana](https://atcoder.jp/users/ngtkana)さんによって運営されている、Rustで競技プログラミングに参加している人・参加したい人向けのサーバ。
 
 - [高専競プロ部](https://discord.com/invite/nhMReq9nMz) - 高専生および関係者で競技プログラミングに参加している人・参加を考えている人向けのサーバ。[tsunamayo123](https://atcoder.jp/users/tsunamayo123)さんが管理・運営されている。
 


### PR DESCRIPTION
Discord サーバー kyoprustecean をご紹介いただきありがとうございます。

設立当初、セキュリティ上の懸念で無期限リンクを発行しておらず、AtCoder Clans にも期限切れのリンクが掲載されており、みなさまにご不便をおかけしすぎているため、このたび発行しようと思いました。

お手数ですがよろしくお願いいたします。
