### PR TITLE
fix: Replace polyfill.io with Cloudflare CDN due to security risk (#12011)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,7 +78,7 @@ extra_javascript:
   - https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js
   - javascripts/link_as_new_tab.js
   - javascripts/mathjax.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
+  - https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6
   - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
 
 # Extensions


### PR DESCRIPTION
polyfill.io ドメインが2024年に悪意ある第三者に買収されたため、
Cloudflare が提供する代替 CDN に置き換えた。

close #12011